### PR TITLE
Fixing Appendix labeling, should start at A now

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -309,7 +309,7 @@
 
 % ============================================
 
-
+\appendix
 \include{Chapters/Appendix}
 
 


### PR DESCRIPTION
Hi again, I noticed that the appendix labels start at the wrong letters, so I added the latex \appendix command, branch is rebased on fhstp master :-)